### PR TITLE
Add a delay so AJAX-heavy websites are fully rendered

### DIFF
--- a/api.js
+++ b/api.js
@@ -9,6 +9,7 @@ var webshot = require('webshot');
  * @param  {Object}     [options]           A set of options that manipulate the image
  * @param  {Number}     [options.width]     The desired width (in pixels) for the generated image, default: 1024
  * @param  {Number}     [options.height]    The desired height (in pixels) for the generated image, default 768
+ * @param  {Number}     [options.delay]     The delay (in seconds) before the screenshot, default 0
  * @param  {Boolean}    [options.full]      If specified, the entire webpage will be screenshotted and the `options.height` property will be ignored
  * @param  {Function}   callback            A standard callback function
  * @param  {Object}     callback.err        An error object (if any)
@@ -18,6 +19,7 @@ var generate = module.exports.generate = function(url, options, callback) {
     options = options || {};
     options.width = options.width || 1024;
     options.height = options.height || 768;
+    options.delay = options.delay || 0;
 
     screengrab(url, options, callback);
 };
@@ -35,7 +37,7 @@ var screengrab = function(url, options, callback) {
     var tempPath = temp.path({suffix: '.png'});
 
     var webshotOptions = {
-        'renderDelay': 2000,
+        'renderDelay': options.delay * 1000,
         'windowSize': {
             'width': options.width,
             'height': options.height

--- a/routes/api.js
+++ b/routes/api.js
@@ -14,6 +14,7 @@ exports.generate = function(req, res) {
     var options = {
         'width': req.param('width'),
         'height': req.param('height'),
+        'delay': req.param('delay'),
         'full': (req.param('full') === 'true')
     };
 

--- a/static/javascript/demo.js
+++ b/static/javascript/demo.js
@@ -6,6 +6,7 @@ $(document).ready(function() {
         var url = $('#url').val();
         var width = $('#width').val();
         var height = $('#height').val();
+        var delay = $('#delay').val();
         var full = $('#full').is(':checked');
 
         // Validate if "something" was provided as a URL
@@ -28,7 +29,7 @@ $(document).ready(function() {
 
         $('#url').parent().removeClass('error');
 
-        var src = '/api/generate?url=' + url + '&width=' + width + '&height=' + height + '&full=' + full;
+        var src = '/api/generate?url=' + url + '&width=' + width + '&height=' + height + '&delay=' + delay + '&full=' + full;
 
         $('.js-generate-btn').html('<i class="fa fa-spinner fa-spin"></i> Generating - this should only take a moment ...');
 

--- a/views/index.ejs
+++ b/views/index.ejs
@@ -87,6 +87,9 @@
                 <label for="height">Height</label>
                 <input type="number" name="height" id="height" class="input-small" value="768" min="100" max="" />
 
+                <label for="delay">Delay</label>
+                <input type="number" name="delay" id="delay" class="input-small" value="0" min="0" max="" />
+
                 <label for="full">
                   <input type="checkbox" name="full" id="full" />
                   Grab whole page (not just visible page)


### PR DESCRIPTION
This PR adds a 2 second delay so AJAX heavy websites are loaded before we take a screenshot
