### PR TITLE
Better image naming (for download and drag-n-drop)

### DIFF
--- a/routes/api.js
+++ b/routes/api.js
@@ -1,5 +1,6 @@
 var fs = require('fs');
 
+var Url = require('url');
 var WebshotAPI = require('../api');
 
 /*!
@@ -8,7 +9,15 @@ var WebshotAPI = require('../api');
 exports.generate = function(req, res) {
     var url = req.param('url');
     if (!url) {
-        res.send(400, 'Missing url');
+        return res.send(400, 'Missing url');
+    }
+
+    var parsedUrl = Url.parse(url);
+    if (!parsedUrl.protocol) {
+        return res.send(400, 'Invalid url, missing protocol');
+    }
+    if (!parsedUrl.hostname) {
+        return res.send(400, 'Invalid url, missing hostname');
     }
 
     var options = {
@@ -21,7 +30,15 @@ exports.generate = function(req, res) {
         if (err) {
             res.send(err.code, err.msg);
         } else {
-            res.sendfile(path, function() {
+            // Construct a prettier name for our image
+            // For example, `http://okfn.org/about/how-we-can-help-you/` will result in `okfn_org_about_how_we_can_help_you.png`
+            var imageName = parsedUrl.hostname.replace(/\W/g, '_');
+            var pathName = parsedUrl.pathname.replace(/\W/g, '_').replace(/_$/, '');
+            if (pathName) {
+                imageName += pathName;
+            }
+            imageName += '.png';
+            res.download(path, imageName, function() {
                 fs.unlink(path);
             });
         }


### PR DESCRIPTION
At the moment if I choose to download I don't get a nice name.

Also if I try to drag and drop into e.g. a github issue it tells me filetype is not supported (my guess is because no .png extension ...)
